### PR TITLE
Dataset expansion

### DIFF
--- a/auto_causality/datasets.py
+++ b/auto_causality/datasets.py
@@ -25,6 +25,18 @@ def synth_ihdp():
     data = data.drop(columns=ignore_cols)
     return data
 
+def ibm_causallib_acic(condition):
+    # load data from IBM causallib 
+    # condition: an integer in [1,20], see https://github.com/IBM/causallib/blob/master/causallib/datasets/data/acic_challenge_2016/README.md
+
+    covariates =  pd.read_csv("https://raw.githubusercontent.com/IBM/causallib/master/causallib/datasets/data/acic_challenge_2016/x.csv")
+    url = f'https://raw.githubusercontent.com/IBM/causallib/master/causallib/datasets/data/acic_challenge_2016/zymu_{condition}.csv'
+    z_y_mu = pd.read_csv(url)
+    z_y_mu['y_factual'] = z_y_mu.apply(lambda row: row['y1'] if row['z'] else row['y0'],axis = 1)
+    data = pd.concat([z_y_mu['z'], z_y_mu['y_factual'], covariates],axis = 1)
+    data.rename(columns = {'z': 'treatment'}, inplace = True)
+
+    return data
 
 def preprocess_dataset(data: pd.DataFrame) -> tuple:
     """preprocesses dataset for causal inference

--- a/auto_causality/datasets.py
+++ b/auto_causality/datasets.py
@@ -118,14 +118,15 @@ def amazon_reviews(rating="pos") -> pd.DataFrame:
     except ImportError:
         gdown = None
 
+    if rating == "pos":
+        url = "https://drive.google.com/file/d/167CYEnYinePTNtKpVpsg0BVkoTwOwQfK/view?usp=sharing"
+    elif rating == "neg":
+        url = "https://drive.google.com/file/d/1b-MPNqxCyWSJE5uyn5-VJUwC8056HM8u/view?usp=sharing"
+
     if gdown:
         try:
             df = pd.read_csv("amazon_" + rating + ".csv")
         except FileNotFoundError:
-            if rating == "pos":
-                url = "https://drive.google.com/file/d/167CYEnYinePTNtKpVpsg0BVkoTwOwQfK/view?usp=sharing"
-            elif rating == "neg":
-                url = "https://drive.google.com/file/d/1b-MPNqxCyWSJE5uyn5-VJUwC8056HM8u/view?usp=sharing"
             gdown.download(url, "amazon_" + rating + ".csv", fuzzy=True)
             df = pd.read_csv("amazon_" + rating + ".csv")
         df.drop(df.columns[[2, 3, 4]], axis=1, inplace=True)
@@ -221,10 +222,7 @@ def synth_acic(condition=1) -> pd.DataFrame:
     )
     cols = covariates.columns
     covariates.rename(
-        columns={
-            c: c.replace("_", "") for c in cols
-        },
-        inplace=True,
+        columns={c: c.replace("_", "") for c in cols}, inplace=True,
     )
     url = (
         "https://raw.githubusercontent.com/IBM/causallib/master/causallib/"

--- a/auto_causality/datasets.py
+++ b/auto_causality/datasets.py
@@ -3,6 +3,62 @@ import numpy as np
 from auto_causality.utils import featurize
 
 
+def amazon_reviews(rating="pos") -> pd.DataFrame:
+    """loads amazon reviews dataset
+    The dataset describes the impact of positive (or negative) reviews for products on Amazon on sales.
+    The authors distinguish between items with more than three reviews (treated) and less than three
+    reviews (untreated). As the rating given by reviews might impact sales, they divide the dataset
+    into products with on average positive (more than 3 starts) or negative (less than three stars)
+    reviews.
+    The dataset consists of 305 covariates (doc2vec features of the review text), a binary treatment
+    variable (more than 3 reviews vs less than three reviews) and a continuous outcome (sales).
+
+    If used for academic purposes, please consider citing the authors:
+    @inproceedings{rakesh2018linked,
+        title={Linked Causal Variational Autoencoder for Inferring Paired Spillover Effects},
+        author={Rakesh, Vineeth and Guo, Ruocheng and Moraffah, Raha and Agarwal, Nitin and Liu, Huan},
+        booktitle={Proceedings of the 27th ACM International Conference on Information and Knowledge Management},
+        pages={1679--1682},
+        year={2018},
+        organization={ACM}
+    }
+    Args:
+        rating (str, optional): choose between positive ('pos') and negative ('neg') reviews. Defaults to 'pos'.
+
+    Returns:
+        pd.DataFrame: dataset with cols "treatment", "y_factual" and covariates "x1" to "x300"
+    """
+    try:
+        assert rating in ["pos", "neg"]
+    except AssertionError:
+        print(
+            "you need to specify which rating dataset you'd like to load. The options are 'pos' or 'neg'"
+        )
+
+    try:
+        import gdown
+    except ImportError:
+        gdown = None
+
+    if gdown:
+        if rating == "pos":
+            url = "https://drive.google.com/file/d/167CYEnYinePTNtKpVpsg0BVkoTwOwQfK/view?usp=sharing"
+        elif rating == "neg":
+            url = "https://drive.google.com/file/d/1b-MPNqxCyWSJE5uyn5-VJUwC8056HM8u/view?usp=sharing"
+        gdown.download(url, "amazon_" + rating + ".csv", fuzzy=True)
+        df = pd.read_csv("amazon_" + rating + ".csv")
+        df.drop(df.columns[[2, 3, 4]], axis=1, inplace=True)
+        df.columns = ["treatment", "y_factual"] + ["x_" + str(i) for i in range(1, 301)]
+        return df
+    else:
+        print(
+            f"""The Amazon dataset is hosted on google drive. As it's quite large, the gdown package is required to download
+            the package automatically. The package can be installed via 'pip install gdown'.
+            Alternatively, you can download it from the following link and store it in the datasets folder:
+            {url}"""
+        )
+
+
 def synth_ihdp() -> pd.DataFrame:
     """loads IHDP dataset
     The Infant Health and Development Program (IHDP) dataset contains data on the impact of visits by specialists

--- a/auto_causality/datasets.py
+++ b/auto_causality/datasets.py
@@ -3,14 +3,14 @@ import numpy as np
 from auto_causality.utils import featurize
 
 
-def lalonde() -> pd.DataFrame:
-    """loads the LaLonde dataset
+def lalonde_nsw() -> pd.DataFrame:
+    """loads the Lalonde NSW dataset
     The dataset described the impact of a job training programme on the real earnings
     of individuals several years later.
     The data consists of the treatment indicator (training yes no), covariates (age, race,
     academic background, real earnings 1976, real earnings 1977) and the outcome (real earnings in 1978)
     See also https://rdrr.io/cran/qte/man/lalonde.html#heading-0 
-    
+
     If used for academic purposes, please consider citing the authors:
     Lalonde, Robert: "Evaluating the Econometric Evaluations of Training Programs," American Economic Review,
     Vol. 76, pp. 604-620

--- a/auto_causality/datasets.py
+++ b/auto_causality/datasets.py
@@ -3,7 +3,26 @@ import numpy as np
 from auto_causality.utils import featurize
 
 
-def synth_ihdp():
+def synth_ihdp() -> pd.DataFrame:
+    """loads IHDP dataset
+    The Infant Health and Development Program (IHDP) dataset contains data on the impact of visits by specialists
+    on the cognitive development of children. The dataset consists of 25 covariates describing various features
+    of these children and their mothers, a binary treatment variable (visit/no visit) and a continuous outcome.
+    
+    If used for academic purposes, consider citing the authors:    
+    @article{hill2011,
+        title={Bayesian nonparametric modeling for causal inference.},
+        author={Hill, Jennifer},
+        journal={Journal of Computational and Graphical Statistics},
+        volume={20},
+        number={1},
+        pages={217--240},
+        year={2011}
+    }
+
+    Returns:
+        pd.DataFrame: dataset for causal inference with cols "treatment", "y_factual" and covariates "x1" to "x25"
+    """
     # load raw data
     data = pd.read_csv(
         "https://raw.githubusercontent.com/AMLab-Amsterdam/CEVAE/master/datasets/IHDP/csv/ihdp_npci_1.csv",
@@ -23,20 +42,49 @@ def synth_ihdp():
     ignore_patterns = ["y_cfactual", "mu"]
     ignore_cols = [c for c in data.columns if any([s in c for s in ignore_patterns])]
     data = data.drop(columns=ignore_cols)
+
     return data
 
-def ibm_causallib_acic(condition):
-    # load data from IBM causallib 
-    # condition: an integer in [1,20], see https://github.com/IBM/causallib/blob/master/causallib/datasets/data/acic_challenge_2016/README.md
 
-    covariates =  pd.read_csv("https://raw.githubusercontent.com/IBM/causallib/master/causallib/datasets/data/acic_challenge_2016/x.csv")
-    url = f'https://raw.githubusercontent.com/IBM/causallib/master/causallib/datasets/data/acic_challenge_2016/zymu_{condition}.csv'
+def synth_acic(condition=1) -> pd.DataFrame:
+    """loads data from ACIC Causal Inference Challenge 2016
+    The dataset consists of 58 covariates, a binary treatment and a continuous response.
+    There are 10 simulated pairs of treatment and response, which can be selected
+    with the condition argument supplied to this function.
+
+    If used for academic purposes, consider citing the authors:
+    @article{dorie2019automated,
+        title={Automated versus do-it-yourself methods for causal inference: Lessons learned from a
+         data analysis competition},
+        author={Dorie, Vincent and Hill, Jennifer and Shalit, Uri and Scott, Marc and Cervone, Dan},
+        journal={Statistical Science},
+        volume={34},
+        number={1},
+        pages={43--68},
+        year={2019},
+        publisher={Institute of Mathematical Statistics}
+    }
+
+    Args:
+        condition (int): in [1,10], corresponds to 10 simulated treatment/response pairs. Defaults to 1.
+
+    Returns:
+        pd.DataFrame: dataset for causal inference with columns "treatment", "y_factual" and covariates "x_1" to "x_58"
+    """
+
+    covariates = pd.read_csv(
+        "https://raw.githubusercontent.com/IBM/causallib/master/causallib/datasets/data/acic_challenge_2016/x.csv"
+    )
+    url = f"https://raw.githubusercontent.com/IBM/causallib/master/causallib/datasets/data/acic_challenge_2016/zymu_{condition}.csv"
     z_y_mu = pd.read_csv(url)
-    z_y_mu['y_factual'] = z_y_mu.apply(lambda row: row['y1'] if row['z'] else row['y0'],axis = 1)
-    data = pd.concat([z_y_mu['z'], z_y_mu['y_factual'], covariates],axis = 1)
-    data.rename(columns = {'z': 'treatment'}, inplace = True)
+    z_y_mu["y_factual"] = z_y_mu.apply(
+        lambda row: row["y1"] if row["z"] else row["y0"], axis=1
+    )
+    data = pd.concat([z_y_mu["z"], z_y_mu["y_factual"], covariates], axis=1)
+    data.rename(columns={"z": "treatment"}, inplace=True)
 
     return data
+
 
 def preprocess_dataset(data: pd.DataFrame) -> tuple:
     """preprocesses dataset for causal inference
@@ -59,10 +107,7 @@ def preprocess_dataset(data: pd.DataFrame) -> tuple:
     data["random"] = np.random.randint(0, 2, size=len(data))
 
     used_df = featurize(
-        data,
-        features=features,
-        exclude_cols=[treatment] + targets,
-        drop_first=False,
+        data, features=features, exclude_cols=[treatment] + targets, drop_first=False,
     )
     used_features = [c for c in used_df.columns if c not in [treatment] + targets]
 

--- a/auto_causality/datasets.py
+++ b/auto_causality/datasets.py
@@ -3,13 +3,54 @@ import numpy as np
 from auto_causality.utils import featurize
 
 
+def nhefs() -> pd.DataFrame:
+    """loads the NHEFS dataset
+    The dataset describes the impact of quitting smoke on weight gain over a period of 11 years
+    The data consists of the treatment (quit smoking yes no), the outcome (change in weight) and
+    a series of covariates of which we include a subset of 9 (see below).
+
+    If used for academic purposes, pelase consider citing the authors:
+    Hernán MA, Robins JM (2020). Causal Inference: What If. Boca Raton: Chapman & Hall/CRC.
+
+    Returns:
+        pd.DataFrame: dataset with cols "treatment", "y_factual" and covariates "x1" to "x9"
+    """
+
+    df = pd.read_csv(
+        "https://cdn1.sph.harvard.edu/wp-content/uploads/sites/1268/1268/20/nhefs.csv"
+    )
+    covariates = [
+        "active",
+        "age",
+        "education",
+        "exercise",
+        "race",
+        "sex",
+        "smokeintensity",
+        "smokeyrs",
+        "wt71",
+    ]
+
+    has_missing = ["wt82"]
+    missing = df[has_missing].isnull().any(axis="columns")
+    df = df.loc[~missing]
+
+    df = df[covariates + ["qsmk"] + ["wt82_71"]]
+    df.rename(columns={"qsmk": "treatment", "wt82_71": "y_factual"}, inplace=True)
+    df.rename(
+        columns={c: "x" + str(i + 1) for i, c in enumerate(covariates)}, inplace=True
+    )
+
+    return df
+
+
 def lalonde_nsw() -> pd.DataFrame:
     """loads the Lalonde NSW dataset
     The dataset described the impact of a job training programme on the real earnings
     of individuals several years later.
     The data consists of the treatment indicator (training yes no), covariates (age, race,
     academic background, real earnings 1976, real earnings 1977) and the outcome (real earnings in 1978)
-    See also https://rdrr.io/cran/qte/man/lalonde.html#heading-0 
+    See also https://rdrr.io/cran/qte/man/lalonde.html#heading-0
 
     If used for academic purposes, please consider citing the authors:
     Lalonde, Robert: "Evaluating the Econometric Evaluations of Training Programs," American Economic Review,

--- a/auto_causality/datasets.py
+++ b/auto_causality/datasets.py
@@ -3,6 +3,41 @@ import numpy as np
 from auto_causality.utils import featurize
 
 
+def lalonde() -> pd.DataFrame:
+    """loads the LaLonde dataset
+    The dataset described the impact of a job training programme on the real earnings
+    of individuals several years later.
+    The data consists of the treatment indicator (training yes no), covariates (age, race,
+    academic background, real earnings 1976, real earnings 1977) and the outcome (real earnings in 1978)
+
+    If used for academic purposes, please consider citing the authors:
+    Lalonde, Robert: "Evaluating the Econometric Evaluations of Training Programs," American Economic Review,
+    Vol. 76, pp. 604-620
+
+    Returns:
+        pd.DataFrame: dataset with cols "treatment", "y_factual" and covariates "x1" to "x8"
+    """
+
+    df_control = pd.read_csv(
+        "https://users.nber.org/~rdehejia/data/nswre74_control.txt", sep=" "
+    ).dropna(axis=1)
+    df_control.columns = (
+        ["treatment"] + ["x_" + str(x) for x in range(1, 9)] + ["y_factual"]
+    )
+    df_treatment = pd.read_csv(
+        "https://users.nber.org/~rdehejia/data/nswre74_treated.txt", sep=" "
+    ).dropna(axis=1)
+    df_treatment.columns = (
+        ["treatment"] + ["x_" + str(x) for x in range(1, 9)] + ["y_factual"]
+    )
+    df = (
+        pd.concat([df_control, df_treatment], axis=0, ignore_index=True)
+        .sample(frac=1)
+        .reset_index(drop=True)
+    )
+    return df
+
+
 def amazon_reviews(rating="pos") -> pd.DataFrame:
     """loads amazon reviews dataset
     The dataset describes the impact of positive (or negative) reviews for products on Amazon on sales.

--- a/auto_causality/datasets.py
+++ b/auto_causality/datasets.py
@@ -8,8 +8,8 @@ def synth_ihdp() -> pd.DataFrame:
     The Infant Health and Development Program (IHDP) dataset contains data on the impact of visits by specialists
     on the cognitive development of children. The dataset consists of 25 covariates describing various features
     of these children and their mothers, a binary treatment variable (visit/no visit) and a continuous outcome.
-    
-    If used for academic purposes, consider citing the authors:    
+
+    If used for academic purposes, consider citing the authors:
     @article{hill2011,
         title={Bayesian nonparametric modeling for causal inference.},
         author={Hill, Jennifer},
@@ -73,9 +73,11 @@ def synth_acic(condition=1) -> pd.DataFrame:
     """
 
     covariates = pd.read_csv(
-        "https://raw.githubusercontent.com/IBM/causallib/master/causallib/datasets/data/acic_challenge_2016/x.csv"
+        """https://raw.githubusercontent.com/IBM/causallib/
+        master/causallib/datasets/data/acic_challenge_2016/x.csv"""
     )
-    url = f"https://raw.githubusercontent.com/IBM/causallib/master/causallib/datasets/data/acic_challenge_2016/zymu_{condition}.csv"
+    url = f"""https://raw.githubusercontent.com/IBM/causallib/master/causallib/
+    datasets/data/acic_challenge_2016/zymu_{condition}.csv"""
     z_y_mu = pd.read_csv(url)
     z_y_mu["y_factual"] = z_y_mu.apply(
         lambda row: row["y1"] if row["z"] else row["y0"], axis=1

--- a/auto_causality/datasets.py
+++ b/auto_causality/datasets.py
@@ -9,7 +9,8 @@ def lalonde() -> pd.DataFrame:
     of individuals several years later.
     The data consists of the treatment indicator (training yes no), covariates (age, race,
     academic background, real earnings 1976, real earnings 1977) and the outcome (real earnings in 1978)
-
+    See also https://rdrr.io/cran/qte/man/lalonde.html#heading-0 
+    
     If used for academic purposes, please consider citing the authors:
     Lalonde, Robert: "Evaluating the Econometric Evaluations of Training Programs," American Economic Review,
     Vol. 76, pp. 604-620

--- a/auto_causality/datasets.py
+++ b/auto_causality/datasets.py
@@ -163,6 +163,10 @@ def synth_acic(condition=1) -> pd.DataFrame:
     Returns:
         pd.DataFrame: dataset for causal inference with columns "treatment", "y_factual" and covariates "x_1" to "x_58"
     """
+    try:
+        assert condition in range(1, 11)
+    except AssertionError:
+        print("'condition' needs to be in [1,10]")
 
     covariates = pd.read_csv(
         """https://raw.githubusercontent.com/IBM/causallib/

--- a/tests/autocausality/test_datasets.py
+++ b/tests/autocausality/test_datasets.py
@@ -1,0 +1,82 @@
+import pytest
+import subprocess
+import sys
+import pandas as pd
+from auto_causality import datasets
+
+
+def check_header(df: pd.DataFrame, n_covariates: int):
+    """checks if header of dataset is in right format
+
+    Args:
+        df (pd.DataFrame): dataset for causal inference, with columns for treatment, outcome and covariates
+        n_covariates (int): number of covariates in dataset
+    """
+
+    cols = list(df.columns)
+    assert "treatment" in cols
+    assert "y_factual" in cols
+    for i in range(1, n_covariates + 1):
+        assert "x" + str(i) in cols
+    xcols = [c for c in cols if "x" in c]
+    assert len(list(df[xcols].columns)) == n_covariates
+
+
+def check_preprocessor(df: pd.DataFrame):
+    """checks if dataset can be preprocessed (dummy encoding of vars etc...)
+
+    Args:
+        df (pd.DataFrame): dataset for causal inference, with cols for treatment, outcome and covariates
+    """
+    x = datasets.preprocess_dataset(df)
+    assert x is not None
+
+
+class TestDatasets:
+    def test_nhefs(self):
+        data = datasets.nhefs()
+        check_header(data, n_covariates=9)
+        check_preprocessor(data)
+
+    def test_lalonde_nsw(self):
+        data = datasets.lalonde_nsw()
+        check_header(data, n_covariates=8)
+        check_preprocessor(data)
+
+    def test_ihdp(self):
+        data = datasets.synth_ihdp()
+        check_header(data, n_covariates=25)
+        check_preprocessor(data)
+
+    def test_acic(self):
+        # test defaults:
+        data = datasets.synth_acic()
+        check_header(data, n_covariates=58)
+        check_preprocessor(data)
+        # test all conditions:
+        for cond in range(1, 11):
+            data = datasets.synth_acic(condition=cond)
+            check_header(data, n_covariates=58)
+            check_preprocessor(data)
+        # sanity check
+        data = datasets.synth_acic(condition=12)
+        assert data is None
+
+    def test_amazon(self):
+        # test error handling:
+        try:
+            import gdown  # noqa F401
+        except ImportError:
+            data = datasets.amazon_reviews()
+            assert data is None
+            subprocess.check_call([sys.executable, "-m", "pip", "install", "gdown"])
+        finally:
+            # test if data can be downloaded and is in right format:
+            for rating in ["pos", "neg"]:
+                data = datasets.amazon_reviews(rating=rating)
+                check_header(data, n_covariates=300)
+                check_preprocessor(data)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])


### PR DESCRIPTION
We have added support for the following datasets:

1. **ACIC Causal Inference Challenge 2016**
This is a synthetic dataset with 58 covariates and 10 simulated pairs of binary treatments and continuous responses.
(So, basically, 10 different datasets). One can choose the condition (treatment/outcome pair) on calling the function ```synth_acic(condition=X)```

1. **NHEFS Dataset**
A dataset that describes the impact of quitting smoking (treatment) on weight change over an 11 year interval, with 9 covariates.

1. **Lalonde NSW**
A dataset that describes the effect of a job training programme (treatment) on the real earnings several years later. Has 8 covariates

1. **Amazon reviews**
This is a massive dataset with 40k observations. It describes the effect of an item having more than 3 reviews on sales, with 300 covariates corresponding to doc2vec embeddings of the rating texts. The dataset is divided into two halves, one with positive reviews (more than 3 stars) and one with negative reviews (less than 3 stars). 

### Notes:
We have added links to the original publications to the docstring of each dataset, together with a small description.

Note that the amazon dataset is hosted on google drive and requires an additional package so that it can be downloaded with Python. I've marked it as optional to the user