### PR TITLE
Skipping test of amazon dataset. fixes #58

### DIFF
--- a/tests/autocausality/test_datasets.py
+++ b/tests/autocausality/test_datasets.py
@@ -34,47 +34,71 @@ def check_preprocessor(df: pd.DataFrame):
 
 class TestDatasets:
     def test_nhefs(self):
+        # check if dataset can be imported:
         data = datasets.nhefs()
+        # check if header variables follow naming convention
         check_header(data, n_covariates=9)
+        # verify that preprocessing works
         check_preprocessor(data)
 
     def test_lalonde_nsw(self):
+        # check if dataset can be imported:
         data = datasets.lalonde_nsw()
+        # check if header variables follow naming convention
         check_header(data, n_covariates=8)
+        # verify that preprocessing works
         check_preprocessor(data)
 
     def test_ihdp(self):
+        # check if dataset can be imported:
         data = datasets.synth_ihdp()
+        # check if header variables follow naming convention
         check_header(data, n_covariates=25)
+        # verify that preprocessing works
         check_preprocessor(data)
 
     def test_acic(self):
         # test defaults:
+        # check if dataset can be imported:
         data = datasets.synth_acic()
+        # check if header variables follow naming convention
         check_header(data, n_covariates=58)
+        # verify that preprocessing works
         check_preprocessor(data)
         # test all conditions:
         for cond in range(1, 11):
+            # check if dataset can be imported:
             data = datasets.synth_acic(condition=cond)
+            # check if header variables follow naming convention
             check_header(data, n_covariates=58)
+            # verify that preprocessing works
             check_preprocessor(data)
         # sanity check
+        # check if dataset can be imported:
         data = datasets.synth_acic(condition=12)
         assert data is None
 
+    @pytest.mark.skip(
+        reason="""this test occassionally fails to download the dataset from google drive,
+        due to gdrive's virus check for big files.
+        This however doesn't indicate problems with the code on our end"""
+    )
     def test_amazon(self):
         # test error handling:
         try:
             import gdown  # noqa F401
         except ImportError:
+            # check if dataset can be imported:
             data = datasets.amazon_reviews()
             assert data is None
             subprocess.check_call([sys.executable, "-m", "pip", "install", "gdown"])
         finally:
-            # test if data can be downloaded and is in right format:
+            # test if data can be imported and is in right format:
             for rating in ["pos", "neg"]:
                 data = datasets.amazon_reviews(rating=rating)
+                # check if header variables follow naming convention
                 check_header(data, n_covariates=300)
+                # verify that preprocessing works
                 check_preprocessor(data)
 
 


### PR DESCRIPTION
The test of the amazon dataset occassionally fails for reasons beyond our control (unable to resolve google drive URL). We agreed to skip the test, as this points to issues with the file host, rather than problems on our end. This fixes #58 