### PR TITLE
Remove silly CI checkbox from PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,7 +4,7 @@ _Describe the problem your PR is trying to solve_
 
 ## Proposed changes
 
-_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 
+_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
 If it fixes a bug or resolves a feature request, be sure to link to that issue._
 
 
@@ -25,7 +25,6 @@ _Put an `x` in the boxes that apply_
 - [ ] Description above provides context of the change
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [ ] Unit tests for changes (not needed for documentation changes)
-- [ ] CI checks pass with my changes
 - [ ] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
 - [ ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
 - [ ] Relevant documentation is updated including usage instructions


### PR DESCRIPTION
## Problem
These run automatically and merges are blocked unless they pass... so
it's a bit silly to ask the author to check this.

## Proposed changes
Removed the checkbox.


## Types of changes

What types of changes does your code introduce to Auto-Causality?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Documentation Update (if none of the other choices apply)


## Checklist

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [ ] CI checks pass with my changes
- [ ] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions
