### PR TITLE
Make the separate validation set for component models more explicit

### DIFF
--- a/auto_causality/models/monkey_patches.py
+++ b/auto_causality/models/monkey_patches.py
@@ -57,8 +57,10 @@ def _refresh_propensity_score(self):
         if self.propensity_score_column not in self._data.columns:
             if self.propensity_score_model is None:
                 raise ValueError(
-                    f"""Propensity score column {self.propensity_score_column} does not exist, nor does a propensity_model.
-                Please specify the column name that has your pre-computed propensity score, or a model to compute it."""
+                    f"""Propensity score column {self.propensity_score_column} does not exist,
+nor does a propensity_model.
+Please specify the column name that has your pre-computed propensity score,
+or a model to compute it."""
                 )
             else:
                 self._data[


### PR DESCRIPTION
Addresses https://github.com/transferwise/auto-causality/issues/177
Turns out it was already using different datasets, but this makes that a bit more explicit. 
## Problem

_Describe the problem your PR is trying to solve_

## Proposed changes

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue._


## Types of changes

What types of changes does your code introduce to Auto-Causality?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [ ] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions
