### PR TITLE
Adjust retrieval of effect modifier names for shap calculation

### DIFF
--- a/auto_causality/shap.py
+++ b/auto_causality/shap.py
@@ -4,7 +4,7 @@ import shap
 
 
 def shap_values(estimate: CausalEstimate, df: pd.DataFrame):
-    nice_df = df[estimate.estimator._effect_modifier_names]
+    nice_df = df[estimate._effect_modifier_names]
     try:
         # this will work on dowhy versions that include https://github.com/microsoft/dowhy/pull/374
         sv = estimate.estimator.shap_values(nice_df)


### PR DESCRIPTION
Noticed that CausalEstimate.estimator._effect_modifier_names does not exist anymore. Effect modifier names are now accessible through CausalEstimate._effect_modifier_names. Broke down shap_values() function in auto-causality/shap.py. Adjusted accordingly.



## Problem

_Describe the problem your PR is trying to solve_


## Proposed changes

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue._


