### PR TITLE
minor fix for sklearn models to work as propensity models

### DIFF
--- a/auto_causality/scoring.py
+++ b/auto_causality/scoring.py
@@ -293,7 +293,9 @@ class Scorer:
                 # .reset_index(drop=True)
                 values[
                     "p"
-                ] = self.psw_estimator.estimator.propensity_model.predict_proba(df)[
+                ] = self.psw_estimator.estimator.propensity_model.predict_proba(
+                        df[self.causal_model.get_effect_modifiers() + self.causal_model.get_common_causes()]
+                    )[
                     :, 1
                 ]
                 values["policy"] = cate_estimate > 0

--- a/tests/autocausality/test_sklearn_propensity_model.py
+++ b/tests/autocausality/test_sklearn_propensity_model.py
@@ -1,0 +1,84 @@
+import pytest
+import warnings
+
+from sklearn.ensemble import RandomForestClassifier
+from sklearn.linear_model import LogisticRegression
+
+from auto_causality import AutoCausality
+from auto_causality.datasets import synth_ihdp, linear_multi_dataset
+from auto_causality.params import SimpleParamService
+
+warnings.filterwarnings("ignore")  # suppress sklearn deprecation warnings for now..
+
+
+class TestCustomPropensityModel(object):
+    def test_sklearn_propensity_model(self):
+        """tests if CATE model can be instantiated and fit to data"""
+
+        from auto_causality.shap import shap_values  # noqa F401
+
+        data = synth_ihdp()
+        data.preprocess_dataset()
+
+        cfg = SimpleParamService(
+            propensity_model=None,
+            outcome_model=None,
+            n_jobs=-1,
+            include_experimental=False,
+            multivalue=False,
+        )
+        estimator_list = cfg.estimator_names_from_patterns("backdoor", "all", 1)
+        # outcome = targets[0]
+        auto_causality = AutoCausality(
+            propensity_model=RandomForestClassifier(),
+            num_samples=len(estimator_list),
+            components_time_budget=10,
+            estimator_list=estimator_list,  # "all",  #
+            use_ray=False,
+            verbose=3,
+            components_verbose=2,
+            resources_per_trial={"cpu": 0.5},
+        )
+
+        auto_causality.fit(data)
+        auto_causality.effect(data.data)
+        auto_causality.score_dataset(data.data, "test")
+
+        # now let's test Shapley values calculation
+        for est_name, scores in auto_causality.scores.items():
+            # Dummy model doesn't support Shapley values
+            # Orthoforest shapley calc is VERY slow
+            if "Dummy" not in est_name and "Ortho" not in est_name:
+
+                print("Calculating Shapley values for", est_name)
+                shap_values(scores["estimator"], data.data[:10])
+
+        print(f"Best estimator: {auto_causality.best_estimator}")
+
+    def test_sklearn_propensity_model_multivalue(self):
+        data = linear_multi_dataset(10000)
+        cfg = SimpleParamService(
+            propensity_model=None,
+            outcome_model=None,
+            n_jobs=-1,
+            include_experimental=False,
+            multivalue=True,
+        )
+        estimator_list = cfg.estimator_names_from_patterns(
+            "backdoor", "all", data_rows=len(data)
+        )
+
+        ac = AutoCausality(
+            propensity_model=LogisticRegression(),
+            estimator_list="all",
+            num_samples=len(estimator_list),
+            components_time_budget=10,
+        )
+        ac.fit(data)
+        # TODO add an effect() call and an effect_tt call
+        print("yay!")
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])
+    # TestEndToEnd().test_endtoend_iv()


### PR DESCRIPTION
## Problem

Use sklearn models as propensity model

## Proposed changes

Minor fix to do prediction only on the columns that the model was also fit on. Sklearn complains if prediction dataset has more columns.


## Types of changes

What types of changes does your code introduce to Auto-Causality?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [ ] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions
