### PR TITLE
CausalForestDML bugfix 

### DIFF
--- a/auto_causality/params.py
+++ b/auto_causality/params.py
@@ -380,7 +380,7 @@ class SimpleParamService:
                     # "min_var_fraction_leaf": tune.uniform(0, 1),
                     "max_features": tune.choice(["auto", "sqrt", "log2", None]),
                     "min_impurity_decrease": tune.uniform(0, 10),
-                    "max_samples": tune.uniform(0, 1),
+                    "max_samples": tune.uniform(0, .5),
                     "min_balancedness_tol": tune.uniform(0, 0.5),
                     "honest": tune.choice([0, 1]),
                     # "inference": tune.choice([0, 1]),


### PR DESCRIPTION
## Problem

Bug exists since inference has been enabled for CausalForestDML.

From CausalForestDML documentation:

`If inference=True, then max_samples must either be an integer smaller than n_samples//2 or a float less than or equal to .5.`

## Proposed changes

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue._


## Types of changes

What types of changes does your code introduce to Auto-Causality?
_Put an `x` in the boxes that apply_

- [ x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [ ] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions
